### PR TITLE
Fix Windows build.

### DIFF
--- a/ac-haskell-example.cabal
+++ b/ac-haskell-example.cabal
@@ -20,9 +20,9 @@ library
                      , ServantExample
                      , TischExample
                      , TraceExample
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , aeson >= 0.11 && < 1.0
-                     , lens >= 4.14 && < 4.16
+                     , lens >= 4.14 && < 4.15
                      , servant-server >= 0.8 && < 0.9
                      , warp >= 3.2 && < 3.3
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.18
+resolver: lts-7.20
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
When building on Windows, fast-logger (a dependency of servant-server) failed to build because of weird C++ macro issues. The original issue was fixed by the fast-logger maintainer, but you need to update your Stackage LTS in order to use the newer version (I'm pretty sure the newer LTS doesn't use fast-logger at all, actually). Original issue: https://github.com/kazu-yamamoto/logger/issues/118

I confirmed that this builds on my Windows 10 machine. The Tisch example crashes, but everything else runs.